### PR TITLE
Add basic header navigation and starter pages

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export default function About() {
+  return (
+    <main className="page">
+      <h1>About</h1>
+      <p>Learn more about our story.</p>
+      <style jsx>{`
+        .page { padding: 24px; }
+      `}</style>
+    </main>
+  )
+}

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export default function Contact() {
+  return (
+    <main className="page">
+      <h1>Contact</h1>
+      <p>Get in touch with us.</p>
+      <style jsx>{`
+        .page { padding: 24px; }
+      `}</style>
+    </main>
+  )
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+import Header from '../components/Header'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Header />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/frontend/app/services/page.tsx
+++ b/frontend/app/services/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export default function Services() {
+  return (
+    <main className="page">
+      <h1>Services</h1>
+      <p>Discover what we offer.</p>
+      <style jsx>{`
+        .page { padding: 24px; }
+      `}</style>
+    </main>
+  )
+}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,0 +1,37 @@
+'use client'
+import Link from 'next/link'
+
+export default function Header() {
+  return (
+    <header className="site-header">
+      <nav>
+        <ul className="menu">
+          <li><Link href="/">Home</Link></li>
+          <li><Link href="/about">About</Link></li>
+          <li><Link href="/services">Services</Link></li>
+          <li><Link href="/contact">Contact</Link></li>
+        </ul>
+      </nav>
+      <style jsx>{`
+        .site-header {
+          background: #0b0b0d;
+          padding: 16px;
+        }
+        .menu {
+          list-style: none;
+          display: flex;
+          gap: 16px;
+          margin: 0;
+          padding: 0;
+        }
+        .menu a {
+          color: #eaeaea;
+          text-decoration: none;
+        }
+        .menu a:hover {
+          text-decoration: underline;
+        }
+      `}</style>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable header component with menu links
- introduce root layout rendering the header on every page
- scaffold About, Services, and Contact pages for a starter site

## Testing
- `npm run lint`
- `npm run build` *(fails: Parsing ecmascript source code failed in app/three-hero.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9855a754832aa2ed070794a74f3d