### PR TITLE
Simplify hero text to 'Wine'

### DIFF
--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -5,8 +5,7 @@
 <header class="hero">
   <canvas id="scene"></canvas>
   <div class="hero-copy container">
-    <h1>Wine reimagined as light and space</h1>
-    <p>Enter the virtual cellar. Scroll down to explore provenance, craft, and limited editions.</p>
+    <h1>Wine</h1>
   </div>
 </header>
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -48,8 +48,7 @@ export default function Home() {
             <header className="hero">
                 <canvas id="scene" />
                 <div className="hero-copy">
-                    <h1>Wine reimagined as light & space</h1>
-                    <p>Scroll to explore.</p>
+                    <h1>Wine</h1>
                 </div>
             </header>
             <div id="scroll-sections">


### PR DESCRIPTION
## Summary
- Reduce hero copy in Flask template to only "Wine"
- Update Next.js hero component to show just "Wine"

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd987d3ce4832abf727e39e28838ce